### PR TITLE
[LF-20/paging-crawler] 네이버 뉴스 크롤러 개발

### DIFF
--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/CrawlJobLauncher.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/CrawlJobLauncher.java
@@ -18,6 +18,7 @@ public class CrawlJobLauncher {
 
     private final JobLauncher jobLauncher;
     private final Job googleNewsCrawlJob;
+    private final Job naverNewsCrawlJob;
 
     private void runCrawlJob(Job crawlJob, String pageUrl) {
         JobParameters jobParameters = new JobParametersBuilder()
@@ -35,6 +36,12 @@ public class CrawlJobLauncher {
     public void runGoogleNewsCrawlJob() {
         for (String pageUrl : NewsPage.GOOGLE_NEWS.getUrls()) {
             runCrawlJob(googleNewsCrawlJob, pageUrl);
+        }
+    }
+
+    public void runNaverNewsCrawlJob() {
+        for (String pageUrl : NewsPage.NAVER_NEWS.getUrls()) {
+            runCrawlJob(naverNewsCrawlJob, pageUrl);
         }
     }
 }

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/CrawlJobLauncher.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/CrawlJobLauncher.java
@@ -20,9 +20,11 @@ public class CrawlJobLauncher {
     private final Job googleNewsCrawlJob;
     private final Job naverNewsCrawlJob;
 
-    private void runCrawlJob(Job crawlJob, String pageUrl) {
+    private void runCrawlJob(Job crawlJob, String pageUrl, NewsPage.Platform platform, NewsPage.Theme theme) {
         JobParameters jobParameters = new JobParametersBuilder()
                 .addString("pageUrl", pageUrl)
+                .addString("platform", platform.name())
+                .addString("theme", theme.name())
                 .addDate("date", Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()))
                 .toJobParameters();
 
@@ -33,15 +35,15 @@ public class CrawlJobLauncher {
         }
     }
 
-    public void runGoogleNewsCrawlJob() {
-        for (String pageUrl : NewsPage.GOOGLE_NEWS.getUrls()) {
-            runCrawlJob(googleNewsCrawlJob, pageUrl);
+    public void runGoogleSportsNewsCrawlJob() {
+        for (String pageUrl : NewsPage.GOOGLE_SPORTS_NEWS.getUrls()) {
+            runCrawlJob(googleNewsCrawlJob, pageUrl, NewsPage.Platform.GOOGLE, NewsPage.Theme.SPORTS);
         }
     }
 
-    public void runNaverNewsCrawlJob() {
-        for (String pageUrl : NewsPage.NAVER_NEWS.getUrls()) {
-            runCrawlJob(naverNewsCrawlJob, pageUrl);
+    public void runNaverSportsNewsCrawlJob() {
+        for (String pageUrl : NewsPage.NAVER_SPORTS_NEWS.getUrls()) {
+            runCrawlJob(naverNewsCrawlJob, pageUrl, NewsPage.Platform.NAVER, NewsPage.Theme.SPORTS);
         }
     }
 }

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/configuration/NaverNewsCrawlJobConfiguration.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/configuration/NaverNewsCrawlJobConfiguration.java
@@ -1,0 +1,36 @@
+package com.livefeed.livefeedcrawler.batch.configuration;
+
+import com.livefeed.livefeedcrawler.batch.reader.NaverNewsItemReader;
+import com.livefeed.livefeedcrawler.batch.writer.NewsItemWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class NaverNewsCrawlJobConfiguration {
+    private static final int chunkSize = 20;
+    private final NaverNewsItemReader naverNewsItemReader;
+    private final NewsItemWriter newsItemWriter;
+
+    @Bean
+    public Job naverNewsCrawlJob(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new JobBuilder("NaverNewsCrawlJob", jobRepository)
+                .start(naverNewsCrawlStep(jobRepository, transactionManager))
+                .build();
+    }
+
+    public Step naverNewsCrawlStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("NaverNewsCrawlStep", jobRepository)
+                .<String, String>chunk(chunkSize, transactionManager)
+                .reader(naverNewsItemReader)
+                .writer(newsItemWriter)
+                .build();
+    }
+}

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/configuration/NaverNewsCrawlJobConfiguration.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/configuration/NaverNewsCrawlJobConfiguration.java
@@ -21,13 +21,13 @@ public class NaverNewsCrawlJobConfiguration {
 
     @Bean
     public Job naverNewsCrawlJob(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-        return new JobBuilder("NaverNewsCrawlJob", jobRepository)
+        return new JobBuilder("naverNewsCrawlJob", jobRepository)
                 .start(naverNewsCrawlStep(jobRepository, transactionManager))
                 .build();
     }
 
     public Step naverNewsCrawlStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-        return new StepBuilder("NaverNewsCrawlStep", jobRepository)
+        return new StepBuilder("naverNewsCrawlStep", jobRepository)
                 .<String, String>chunk(chunkSize, transactionManager)
                 .reader(naverNewsItemReader)
                 .writer(newsItemWriter)

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/reader/NaverNewsItemReader.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/reader/NaverNewsItemReader.java
@@ -1,0 +1,141 @@
+package com.livefeed.livefeedcrawler.batch.reader;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.data.AbstractPaginatedDataItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+@Slf4j
+@StepScope
+@Component
+public class NaverNewsItemReader extends AbstractPaginatedDataItemReader<String> {
+
+    @Value("#{jobParameters[pageUrl]}")
+    private String pageUrl;
+
+    @Value("#{jobParameters[date]}")
+    private Date date;
+
+    private int maxPage;
+    private static final int PAGE_SIZE = 20;
+    private static final int PAGINATION_SIZE = 10;
+    private static final int MAX_PUBLICATION_TIME_DIFFERENCE_IN_MINUTES = 30;
+    private static final SimpleDateFormat searchDateFormat = new SimpleDateFormat("yyyyMMdd");
+    private static final SimpleDateFormat publicationTimeFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm");
+
+    public NaverNewsItemReader() {
+        super();
+        setPageSize(PAGE_SIZE);
+        setExecutionContextName(ClassUtils.getShortName(NaverNewsItemReader.class));
+    }
+
+    @Override
+    protected Iterator<String> doPageRead() {
+        if (page > maxPage) {
+            return null;
+        }
+
+        WebDriver driver = new ChromeDriver();
+        List<String> articleUrls = new ArrayList<>();
+
+        try {
+            openPage(driver, page);
+            readArticles(driver, articleUrls);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        } finally {
+            driver.quit();
+        }
+
+        return articleUrls.iterator();
+    }
+
+    @Override
+    protected void doOpen() {
+        WebDriverManager.chromedriver().setup();
+        WebDriver driver = new ChromeDriver();
+
+        try {
+            setMaxPage(driver);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        } finally {
+            driver.quit();
+        }
+    }
+
+    @Override
+    protected void doClose() {
+        complete();
+    }
+
+    private void openPage(WebDriver driver, int page) {
+        String queryParameter = "?date=" + searchDateFormat.format(date) + "&isphoto=N&page=" + (page + 1);
+        driver.get(pageUrl + queryParameter);
+    }
+
+    private void setMaxPage(WebDriver driver) {
+        openPage(driver, maxPage);
+
+        WebElement paginateElement = driver.findElement(By.cssSelector(".paginate"));
+        boolean nextButtonExists = paginateElement.findElements(By.linkText("다음")).size() > 0;
+
+        if (nextButtonExists) {
+            maxPage += PAGINATION_SIZE;
+            setMaxPage(driver);
+        } else {
+            List<WebElement> dataIdElements = paginateElement.findElements(By.cssSelector("a[data-id]"));
+            for (WebElement dataIdElement : dataIdElements) {
+                String dataIdValue = dataIdElement.getAttribute("data-id");
+                int pageValue = Integer.parseInt(dataIdValue) - 1;
+                if (pageValue > maxPage) {
+                    maxPage = pageValue;
+                }
+            }
+        }
+    }
+
+    private void readArticles(WebDriver driver, List<String> articleUrls) {
+        List<WebElement> articleList = driver.findElements(By.cssSelector(".news_list .text"));
+
+        for (WebElement articleElement : articleList) {
+            if (isArticleOverTimeLimit(articleElement)) {
+                complete();
+                break;
+            }
+
+            String articleUrl = articleElement.findElement(By.cssSelector(".title")).getAttribute("href");
+            articleUrls.add(articleUrl);
+        }
+    }
+
+    private boolean isArticleOverTimeLimit(WebElement articleElement) {
+        String publicationTime = articleElement.findElement(By.cssSelector(".time")).getText();
+
+        try {
+            Date publicationDate = publicationTimeFormat.parse(publicationTime);
+            long timeDifference = (date.getTime() - publicationDate.getTime()) / (1000 * 60);
+            if (timeDifference > MAX_PUBLICATION_TIME_DIFFERENCE_IN_MINUTES) {
+                return true;
+            }
+        } catch (Exception e) {
+            log.error(e. getMessage(), e);
+        }
+
+        return false;
+    }
+
+    private void complete() {
+        maxPage = 0;
+    }
+}

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/writer/NewsItemWriter.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/batch/writer/NewsItemWriter.java
@@ -2,21 +2,32 @@ package com.livefeed.livefeedcrawler.batch.writer;
 
 import com.livefeed.livefeedcommon.kafka.producer.KafkaProducerTemplate;
 import com.livefeed.livefeedcommon.kafka.topic.KafkaTopic;
+import com.livefeed.livefeedcrawler.common.NewsKey;
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
+@StepScope
 @RequiredArgsConstructor
 public class NewsItemWriter implements ItemWriter<String> {
 
-    private final KafkaProducerTemplate<String, String> kafkaProducer;
+    @Value("#{jobParameters[platform]}")
+    private String platform;
+
+    @Value("#{jobParameters[theme]}")
+    private String theme;
+
+    private final KafkaProducerTemplate<NewsKey, String> kafkaProducer;
 
     @Override
     public void write(Chunk<? extends String> chunk) {
+        NewsKey newsKey = NewsKey.of(platform, theme);
         for (String articleUrl : chunk.getItems()) {
-            kafkaProducer.sendMessage(KafkaTopic.LIVEFEED_URL, articleUrl);
+            kafkaProducer.sendMessage(KafkaTopic.LIVEFEED_URL, newsKey, articleUrl);
         }
     }
 }

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/common/NewsKey.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/common/NewsKey.java
@@ -1,0 +1,11 @@
+package com.livefeed.livefeedcrawler.common;
+
+public record NewsKey(
+        String platform,
+        String theme
+) {
+
+    public static NewsKey of(String platform, String theme) {
+        return new NewsKey(platform, theme);
+    }
+}

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/common/NewsPage.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/common/NewsPage.java
@@ -4,11 +4,16 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Getter
 @RequiredArgsConstructor
 public enum NewsPage {
-    GOOGLE_NEWS(List.of(GoogleNewsPage.SPORTS.url));
+    GOOGLE_NEWS(List.of(GoogleNewsPage.SPORTS.url)),
+    NAVER_NEWS(Stream.of(NaverNewsPage.SPORTS.urls)
+            .flatMap(List::stream)
+            .collect(Collectors.toList()));
 
     private final List<String> urls;
 
@@ -17,5 +22,29 @@ public enum NewsPage {
         SPORTS("https://news.google.com/topics/CAAqJggKIiBDQkFTRWdvSUwyMHZNRFp1ZEdvU0FtdHZHZ0pMVWlnQVAB?hl=ko&gl=KR&ceid=KR%3Ako");
 
         private final String url;
+    }
+
+    @RequiredArgsConstructor
+    private enum NaverNewsPage {
+        SPORTS(List.of(NaverSportsNewsPage.KBASEBALL.url, NaverSportsNewsPage.WBASEBALL.url,
+                NaverSportsNewsPage.KFOOTBALL.url, NaverSportsNewsPage.WFOOTBALL.url,
+                NaverSportsNewsPage.BASKETBALL.url, NaverSportsNewsPage.VOLLEYBALL.url,
+                NaverSportsNewsPage.GOLF.url, NaverSportsNewsPage.GENERAL.url));
+
+        private final List<String> urls;
+
+        @RequiredArgsConstructor
+        private enum NaverSportsNewsPage {
+            KBASEBALL("https://sports.naver.com/kbaseball/news/index"),
+            WBASEBALL("https://sports.naver.com/wbaseball/news/index"),
+            KFOOTBALL("https://sports.naver.com/kfootball/news/index"),
+            WFOOTBALL("https://sports.naver.com/wfootball/news/index"),
+            BASKETBALL("https://sports.naver.com/basketball/news/index"),
+            VOLLEYBALL("https://sports.naver.com/volleyball/news/index"),
+            GOLF("https://sports.naver.com/golf/news/index"),
+            GENERAL("https://sports.naver.com/general/news/index");
+
+            private final String url;
+        }
     }
 }

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/common/NewsPage.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/common/NewsPage.java
@@ -4,18 +4,28 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Getter
 @RequiredArgsConstructor
 public enum NewsPage {
-    GOOGLE_NEWS(List.of(GoogleNewsPage.SPORTS.url)),
-    NAVER_NEWS(Stream.of(NaverNewsPage.SPORTS.urls)
-            .flatMap(List::stream)
-            .collect(Collectors.toList()));
 
+    GOOGLE_SPORTS_NEWS(Platform.GOOGLE, Theme.SPORTS, List.of(GoogleNewsPage.SPORTS.url)),
+    NAVER_SPORTS_NEWS(Platform.NAVER, Theme.SPORTS, NaverNewsPage.SPORTS.urls);
+
+    private final Platform platform;
+    private final Theme theme;
     private final List<String> urls;
+
+    @RequiredArgsConstructor
+    public enum Platform {
+        GOOGLE,
+        NAVER
+    }
+
+    @RequiredArgsConstructor
+    public enum Theme {
+        SPORTS
+    }
 
     @RequiredArgsConstructor
     private enum GoogleNewsPage {
@@ -26,15 +36,13 @@ public enum NewsPage {
 
     @RequiredArgsConstructor
     private enum NaverNewsPage {
-        SPORTS(List.of(NaverSportsNewsPage.KBASEBALL.url, NaverSportsNewsPage.WBASEBALL.url,
-                NaverSportsNewsPage.KFOOTBALL.url, NaverSportsNewsPage.WFOOTBALL.url,
-                NaverSportsNewsPage.BASKETBALL.url, NaverSportsNewsPage.VOLLEYBALL.url,
-                NaverSportsNewsPage.GOLF.url, NaverSportsNewsPage.GENERAL.url));
+        SPORTS(List.of(Sports.KBASEBALL.url, Sports.WBASEBALL.url, Sports.KFOOTBALL.url, Sports.WFOOTBALL.url,
+                Sports.BASKETBALL.url, Sports.VOLLEYBALL.url, Sports.GOLF.url, Sports.GENERAL.url));
 
         private final List<String> urls;
 
         @RequiredArgsConstructor
-        private enum NaverSportsNewsPage {
+        private enum Sports {
             KBASEBALL("https://sports.naver.com/kbaseball/news/index"),
             WBASEBALL("https://sports.naver.com/wbaseball/news/index"),
             KFOOTBALL("https://sports.naver.com/kfootball/news/index"),

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/scheduler/CrawlerScheduler.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/scheduler/CrawlerScheduler.java
@@ -13,8 +13,12 @@ public class CrawlerScheduler {
 
     private final CrawlJobLauncher crawlJobLauncher;
 
-    @Scheduled(fixedRate = 300000)
     public void crawlGoogleNews() {
         crawlJobLauncher.runGoogleNewsCrawlJob();
+    }
+
+    @Scheduled(fixedRate = 300000)
+    public void crawlNaverNews() {
+        crawlJobLauncher.runNaverNewsCrawlJob();
     }
 }

--- a/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/scheduler/CrawlerScheduler.java
+++ b/LiveFeedCrawler/src/main/java/com/livefeed/livefeedcrawler/scheduler/CrawlerScheduler.java
@@ -14,11 +14,11 @@ public class CrawlerScheduler {
     private final CrawlJobLauncher crawlJobLauncher;
 
     public void crawlGoogleNews() {
-        crawlJobLauncher.runGoogleNewsCrawlJob();
+        crawlJobLauncher.runGoogleSportsNewsCrawlJob();
     }
 
     @Scheduled(fixedRate = 300000)
     public void crawlNaverNews() {
-        crawlJobLauncher.runNaverNewsCrawlJob();
+        crawlJobLauncher.runNaverSportsNewsCrawlJob();
     }
 }

--- a/LiveFeedCrawler/src/main/resources/application-prod.yaml
+++ b/LiveFeedCrawler/src/main/resources/application-prod.yaml
@@ -2,7 +2,7 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      key-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
   datasource:

--- a/LiveFeedCrawler/src/test/java/com/livefeed/livefeedcrawler/batch/GoogleNewsCrawlJobTest.java
+++ b/LiveFeedCrawler/src/test/java/com/livefeed/livefeedcrawler/batch/GoogleNewsCrawlJobTest.java
@@ -89,13 +89,23 @@ public class GoogleNewsCrawlJobTest {
 
     @Test
     @DisplayName("기사 url을 kafka로 전송하는 ItemWriter가 정상 실행된다.")
-    void writeGoogleNewsItem() {
-        writer.write(new Chunk<>(NewsPage.GOOGLE_NEWS.getUrls()));
+    void writeGoogleNewsItem() throws Exception {
+        // given
+        JobParameters jobParameters = createJobParameters();
+        StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution(jobParameters);
+
+        // when
+        StepScopeTestUtils.doInStepScope(stepExecution, () -> {
+            writer.write(new Chunk<>(NewsPage.GOOGLE_SPORTS_NEWS.getUrls()));
+            return null;
+        });
     }
 
     JobParameters createJobParameters() {
         return new JobParametersBuilder()
-                .addString("pageUrl", NewsPage.GOOGLE_NEWS.getUrls().get(0))
+                .addString("pageUrl", NewsPage.GOOGLE_SPORTS_NEWS.getUrls().get(0))
+                .addString("platform", NewsPage.Platform.GOOGLE.name())
+                .addString("theme", NewsPage.Theme.SPORTS.name())
                 .addDate("date", Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()))
                 .toJobParameters();
     }

--- a/LiveFeedCrawler/src/test/java/com/livefeed/livefeedcrawler/batch/NaverNewsCrawlJobTest.java
+++ b/LiveFeedCrawler/src/test/java/com/livefeed/livefeedcrawler/batch/NaverNewsCrawlJobTest.java
@@ -1,8 +1,8 @@
 package com.livefeed.livefeedcrawler.batch;
 
 import com.livefeed.livefeedcrawler.batch.configuration.BatchTestConfiguration;
-import com.livefeed.livefeedcrawler.batch.configuration.GoogleNewsCrawlJobConfiguration;
-import com.livefeed.livefeedcrawler.batch.reader.GoogleNewsItemReader;
+import com.livefeed.livefeedcrawler.batch.configuration.NaverNewsCrawlJobConfiguration;
+import com.livefeed.livefeedcrawler.batch.reader.NaverNewsItemReader;
 import com.livefeed.livefeedcrawler.batch.writer.NewsItemWriter;
 import com.livefeed.livefeedcrawler.common.NewsPage;
 import org.junit.jupiter.api.Disabled;
@@ -24,24 +24,24 @@ import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 @SpringBatchTest
 @EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:9094", "port=9094" })
-@SpringBootTest(classes = {GoogleNewsItemReader.class, NewsItemWriter.class, GoogleNewsCrawlJobConfiguration.class, BatchTestConfiguration.class})
-public class GoogleNewsCrawlJobTest {
+@SpringBootTest(classes = {NaverNewsItemReader.class, NewsItemWriter.class, NaverNewsCrawlJobConfiguration.class, BatchTestConfiguration.class})
+public class NaverNewsCrawlJobTest {
 
     @Autowired
     private JobLauncherTestUtils jobLauncher;
 
     @Autowired
-    private GoogleNewsItemReader reader;
+    private NaverNewsItemReader reader;
 
     @Autowired
     private NewsItemWriter writer;
 
     @Test
-    @DisplayName("구글 뉴스 크롤링 Job이 정상 실행된다.")
-    void runGoogleNewsCrawlJob() throws Exception {
+    @Disabled
+    @DisplayName("네이버 뉴스 크롤링 Job이 정상 실행된다.")
+    void runNaverNewsCrawlJob() throws Exception {
         // given
         JobParameters jobParameters = createJobParameters();
 
@@ -54,13 +54,14 @@ public class GoogleNewsCrawlJobTest {
     }
 
     @Test
-    @DisplayName("구글 뉴스 크롤링 Step이 정상 실행된다.")
+    @Disabled
+    @DisplayName("네이버 뉴스 크롤링 Step이 정상 실행된다.")
     void runGoogleNewsCrawlStep() {
         // given
         JobParameters jobParameters = createJobParameters();
 
         // when
-        JobExecution jobExecution = jobLauncher.launchStep("googleNewsCrawlStep", jobParameters);
+        JobExecution jobExecution = jobLauncher.launchStep("naverNewsCrawlStep", jobParameters);
 
         // then
         assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
@@ -68,7 +69,8 @@ public class GoogleNewsCrawlJobTest {
     }
 
     @Test
-    @DisplayName("구글 뉴스 페이지의 기사 url을 크롤링하는 ItemReader가 정상 실행된다.")
+    @Disabled
+    @DisplayName("네이버 뉴스 페이지의 기사 url을 크롤링하는 ItemReader가 정상 실행된다.")
     void readGoogleNewsItem() throws Exception {
         // given
         JobParameters jobParameters = createJobParameters();
@@ -84,18 +86,18 @@ public class GoogleNewsCrawlJobTest {
 
         // then
         assertThat(articleUrl).isNotBlank();
-        assertThat(articleUrl).startsWith("https://news.google.com/articles/");
+        assertThat(articleUrl).startsWith("https://sports.naver.com/");
     }
 
     @Test
     @DisplayName("기사 url을 kafka로 전송하는 ItemWriter가 정상 실행된다.")
     void writeGoogleNewsItem() {
-        writer.write(new Chunk<>(NewsPage.GOOGLE_NEWS.getUrls()));
+        writer.write(new Chunk<>(NewsPage.NAVER_NEWS.getUrls()));
     }
 
     JobParameters createJobParameters() {
         return new JobParametersBuilder()
-                .addString("pageUrl", NewsPage.GOOGLE_NEWS.getUrls().get(0))
+                .addString("pageUrl", NewsPage.NAVER_NEWS.getUrls().get(0))
                 .addDate("date", Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()))
                 .toJobParameters();
     }

--- a/LiveFeedCrawler/src/test/java/com/livefeed/livefeedcrawler/batch/NaverNewsCrawlJobTest.java
+++ b/LiveFeedCrawler/src/test/java/com/livefeed/livefeedcrawler/batch/NaverNewsCrawlJobTest.java
@@ -91,13 +91,23 @@ public class NaverNewsCrawlJobTest {
 
     @Test
     @DisplayName("기사 url을 kafka로 전송하는 ItemWriter가 정상 실행된다.")
-    void writeGoogleNewsItem() {
-        writer.write(new Chunk<>(NewsPage.NAVER_NEWS.getUrls()));
+    void writeGoogleNewsItem() throws Exception {
+        // given
+        JobParameters jobParameters = createJobParameters();
+        StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution(jobParameters);
+
+        // when
+        StepScopeTestUtils.doInStepScope(stepExecution, () -> {
+            writer.write(new Chunk<>(NewsPage.NAVER_SPORTS_NEWS.getUrls()));
+            return null;
+        });
     }
 
     JobParameters createJobParameters() {
         return new JobParametersBuilder()
-                .addString("pageUrl", NewsPage.NAVER_NEWS.getUrls().get(0))
+                .addString("pageUrl", NewsPage.NAVER_SPORTS_NEWS.getUrls().get(0))
+                .addString("platform", NewsPage.Platform.NAVER.name())
+                .addString("theme", NewsPage.Theme.SPORTS.name())
                 .addDate("date", Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()))
                 .toJobParameters();
     }

--- a/LiveFeedCrawler/src/test/resources/application.yaml
+++ b/LiveFeedCrawler/src/test/resources/application.yaml
@@ -4,7 +4,7 @@ spring:
   kafka:
     bootstrap-servers: localhost:9094
     producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      key-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
   datasource:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
- Selenium을 이용하여 네이버 뉴스 크롤러 개발
    네이버 뉴스 페이지를 넘겨가며 현재 시간으로부터 30분 이내에 발행된 기사 url을 읽어 kafka에 전송하도록 구현
- Spring Batch Chunk 방식 적용: url 20개 단위 실행
- Spring Scheduler 적용: 5분 단위 실행
- Spring Batch Job, Step, ItemReader, ItemWriter 단위 테스트 작성
- Kafka Key 추가