### PR TITLE
[LF-37/parsing] 파싱 에러 및 DB 정합성 확인

### DIFF
--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/common/dto/processorvaluedto/ParseResultDto.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/common/dto/processorvaluedto/ParseResultDto.java
@@ -3,6 +3,7 @@ package com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto;
 import com.livefeed.livefeedbatch.batch.common.dto.ItemDtoInterface;
 
 public record ParseResultDto(
+        String url,
         String articleTitle,
         String publicationTime,
         String pressCompanyName,
@@ -13,7 +14,7 @@ public record ParseResultDto(
         String bodyHtml
 ) implements ItemDtoInterface<ParseResultDto> {
 
-    public static ParseResultDto from(HeaderDto header, BodyDto body) {
+    public static ParseResultDto from(String url, HeaderDto header, BodyDto body) {
         String articleTitle = header.articleTitle();
         String publicationTime = header.publicationTime();
         String pressCompanyName = header.pressCompanyName();
@@ -23,7 +24,7 @@ public record ParseResultDto(
         String headerHtml = replaceTabAndEnterToBlank(header.html());
         String bodyHtml = replaceTabAndEnterToBlank(body.html());
 
-        return new ParseResultDto(articleTitle, publicationTime, pressCompanyName, journalistName, journalistEmail, originArticleUrl, headerHtml, bodyHtml);
+        return new ParseResultDto(url, articleTitle, publicationTime, pressCompanyName, journalistName, journalistEmail, originArticleUrl, headerHtml, bodyHtml);
     }
 
     private static String replaceTabAndEnterToBlank(String html) {

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/NaverNewsContentProcessor.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/NaverNewsContentProcessor.java
@@ -23,7 +23,7 @@ public class NaverNewsContentProcessor implements ItemProcessor<String, ItemDto>
     private final RedisOperations<String, Boolean> redisOperations;
 
     @Override
-    public ItemDto process(String url) throws Exception {
+    public ItemDto process(String url) {
         if (redisOperations.isDuplicate(url, true)) {
             return null;
         }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParser.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 @Component
 public class NameAndEmailParser {
 
+    private static final String NAME_SUFFIX = "기자";
     private static final List<String> nameEmailPattern = List.of("([\\p{L}\\s]+)(?:\\s?\\(([^)]+)\\)|\\s([^\\s]+))");
 
     public Pair<String, String> extractNameAndEmail(String input) {
@@ -18,12 +19,20 @@ public class NameAndEmailParser {
             Matcher matcher = pattern.matcher(input);
 
             if (matcher.find()) {
-                String name = matcher.group(1).trim(); // 이름 추출
+                String name = addSuffix(matcher.group(1).trim()); // 이름 추출
                 String email = matcher.group(2) != null ? matcher.group(2) : matcher.group(3); // 이메일 추출
 
                 return Pair.of(name, email);
             }
         }
         return null;
+    }
+
+    private String addSuffix(String name) {
+        int index = name.indexOf(NAME_SUFFIX);
+        if (index == -1) {
+            return name + " " + NAME_SUFFIX;
+        }
+        return name;
     }
 }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParser.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParser.java
@@ -1,0 +1,29 @@
+package com.livefeed.livefeedbatch.batch.processor.parser.parser;
+
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class NameAndEmailParser {
+
+    private static final List<String> nameEmailPattern = List.of("([\\p{L}\\s]+)(?:\\s?\\(([^)]+)\\)|\\s([^\\s]+))");
+
+    public Pair<String, String> extractNameAndEmail(String input) {
+        for (String patternString : nameEmailPattern) {
+            Pattern pattern = Pattern.compile(patternString);
+            Matcher matcher = pattern.matcher(input);
+
+            if (matcher.find()) {
+                String name = matcher.group(1).trim(); // 이름 추출
+                String email = matcher.group(2) != null ? matcher.group(2) : matcher.group(3); // 이메일 추출
+
+                return Pair.of(name, email);
+            }
+        }
+        return null;
+    }
+}

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/Parser.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/Parser.java
@@ -18,8 +18,7 @@ public abstract class Parser {
         WebDriver driver = ChromeDriverProvider.getDriver();
 
         try {
-            driver.get(url);
-            return parse(driver);
+            return parse(url, driver);
         } catch (Exception e) {
             log.error("파싱 도중 에러가 발생했습니다. ", e);
             throw new ParsingException(e.getMessage());
@@ -28,10 +27,11 @@ public abstract class Parser {
         }
     }
 
-    private ParseResultDto parse(WebDriver driver) {
+    private ParseResultDto parse(String url, WebDriver driver) {
+        driver.get(url);
         HeaderDto headerDto = parseHeader(driver);
         BodyDto bodyDto = parseBody(driver);
-        return ParseResultDto.from(headerDto, bodyDto);
+        return ParseResultDto.from(url, headerDto, bodyDto);
     }
 
     abstract protected HeaderDto parseHeader(WebDriver driver);

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parsermanager/ArticleParserManager.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parsermanager/ArticleParserManager.java
@@ -19,8 +19,11 @@ public class ArticleParserManager implements ParserManager {
 
     @Override
     public ParseResultDto parseWebPage(UrlInfo key, String url) {
-        Parser parser = parserList.stream().filter(p -> p.support(key))
-                .findFirst().orElseThrow(() -> new NoMatchingParserException("해당하는 파서가 존재하지 않습니다."));
+        log.info("parseWebPage method url = {}", url);
+        Parser parser = parserList.stream()
+                .filter(p -> p.support(key))
+                .findFirst()
+                .orElseThrow(() -> new NoMatchingParserException("해당하는 파서가 존재하지 않습니다."));
 
         return parser.parseWebPage(url);
     }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/reader/NaverNewsUrlReader.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/reader/NaverNewsUrlReader.java
@@ -59,7 +59,6 @@ public class NaverNewsUrlReader extends AbstractPaginatedDataItemReader<String> 
         } finally {
             driver.quit();
         }
-
         return articleUrls.iterator();
     }
 
@@ -85,7 +84,6 @@ public class NaverNewsUrlReader extends AbstractPaginatedDataItemReader<String> 
     private void openPage(WebDriver driver, int page) {
         String queryParameter = "?date=" + searchDateFormat.format(date) + "&isphoto=N&page=" + (page + 1);
         driver.get(pageUrl + queryParameter);
-        log.info("openPage: {}", pageUrl + queryParameter);
     }
 
     private void setMaxPage(WebDriver driver) {
@@ -119,7 +117,6 @@ public class NaverNewsUrlReader extends AbstractPaginatedDataItemReader<String> 
             }
 
             String articleUrl = articleElement.findElement(By.cssSelector(".title")).getAttribute("href");
-            log.info("articleUrl: {}", articleUrl);
             articleUrls.add(articleUrl);
         }
     }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsUrlWriter.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsUrlWriter.java
@@ -3,10 +3,7 @@ package com.livefeed.livefeedbatch.batch.writer;
 import com.livefeed.livefeedbatch.batch.common.dto.ItemDto;
 import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
 import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.ParseResultDto;
-import com.livefeed.livefeedbatch.batch.writer.elasticsearch.entity.ElasticsearchArticle;
-import com.livefeed.livefeedbatch.batch.writer.elasticsearch.repository.ArticleElasticsearchRepository;
-import com.livefeed.livefeedbatch.batch.writer.rdb.entity.Article;
-import com.livefeed.livefeedbatch.batch.writer.rdb.service.RdbSaveService;
+import com.livefeed.livefeedbatch.batch.writer.domain.DataSaver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
@@ -20,21 +17,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NewsUrlWriter implements ItemWriter<ItemDto> {
 
-    private final RdbSaveService rdbSaveService;
-    private final ArticleElasticsearchRepository articleElasticsearchRepository;
+    private final DataSaver dataSaver;
 
     @Override
-    public void write(Chunk<? extends ItemDto> chunk) throws Exception {
+    public void write(Chunk<? extends ItemDto> chunk) {
         List<? extends ItemDto> items = chunk.getItems();
 
         for (ItemDto item : items) {
             UrlInfo key = item.urlInfo();
             ParseResultDto value = (ParseResultDto) item.itemDtoInterface().getValue();
-            log.info("kafka consumerRecord key = {}, articleValue = {}", key, value);
-            Article article = rdbSaveService.saveArticle(key, value);
-
-            ElasticsearchArticle elasticsearchArticle = ElasticsearchArticle.from(article, key, value);
-            articleElasticsearchRepository.save(elasticsearchArticle);
+            try {
+                dataSaver.saveArticle(key, value);
+            } catch (Exception e) {
+                log.error("DB Exception Occur message = {} and Error Article Title = {}", e.getMessage(), value.url());
+            }
         }
     }
 }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsUrlWriter.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsUrlWriter.java
@@ -30,7 +30,7 @@ public class NewsUrlWriter implements ItemWriter<ItemDto> {
         for (ItemDto item : items) {
             UrlInfo key = item.urlInfo();
             ParseResultDto value = (ParseResultDto) item.itemDtoInterface().getValue();
-            log.info("kafka consumerRecord key = {}, articleTitle = {}", key, value.articleTitle());
+            log.info("kafka consumerRecord key = {}, articleValue = {}", key, value);
             Article article = rdbSaveService.saveArticle(key, value);
 
             ElasticsearchArticle elasticsearchArticle = ElasticsearchArticle.from(article, key, value);

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/domain/DataSaver.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/domain/DataSaver.java
@@ -1,0 +1,30 @@
+package com.livefeed.livefeedbatch.batch.writer.domain;
+
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
+import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.ParseResultDto;
+import com.livefeed.livefeedbatch.batch.writer.elasticsearch.entity.ElasticsearchArticle;
+import com.livefeed.livefeedbatch.batch.writer.elasticsearch.repository.ArticleElasticsearchRepository;
+import com.livefeed.livefeedbatch.batch.writer.rdb.entity.Article;
+import com.livefeed.livefeedbatch.batch.writer.rdb.service.RdbSaveService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataSaver {
+
+    private final RdbSaveService rdbSaveService;
+    private final ArticleElasticsearchRepository articleElasticsearchRepository;
+
+    @Transactional
+    public void saveArticle(UrlInfo key, ParseResultDto value) {
+        Article article = rdbSaveService.saveArticle(key, value);
+
+        ElasticsearchArticle elasticsearchArticle = ElasticsearchArticle.from(article, key, value);
+        articleElasticsearchRepository.save(elasticsearchArticle);
+    }
+
+}

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/rdb/service/RdbSaveService.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/rdb/service/RdbSaveService.java
@@ -21,7 +21,6 @@ public class RdbSaveService {
     private final CategoryRepository categoryRepository;
     private final ArticleRepository articleRepository;
 
-    @Transactional
     public Article saveArticle(UrlInfo key, ParseResultDto value) {
 
         Category category = categoryRepository.findByServiceAndPlatformAndTheme(key.service(), key.platform(), key.theme())

--- a/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParserTest.java
+++ b/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParserTest.java
@@ -1,0 +1,56 @@
+package com.livefeed.livefeedbatch.batch.processor.parser.parser;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.util.Pair;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NameAndEmailParserTest {
+
+    private NameAndEmailParser nameAndEmailParser;
+
+    @BeforeEach
+    void setUp() {
+        nameAndEmailParser = new NameAndEmailParser();
+    }
+
+    @DisplayName("이름 (이메일) 형식의 패턴을 찾는지 확인하는 테스트")
+    @Test
+    void findPattern1() {
+        // given
+        String text = "홍길동 (hong@example.com)";
+        // when
+        Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
+        // then
+        assertThat(result.getFirst()).isEqualTo("홍길동");
+        assertThat(result.getSecond()).isEqualTo("hong@example.com");
+    }
+
+    @DisplayName("이름(이메일) 형식의 패턴을 찾는지 확인하는 테스트")
+    @Test
+    void findPattern2() {
+        // given
+        String text = "홍길동(hong@example.com)";
+        // when
+        Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
+        // then
+        assertThat(result.getFirst()).isEqualTo("홍길동");
+        assertThat(result.getSecond()).isEqualTo("hong@example.com");
+    }
+
+    @DisplayName("이름 이메일 형식의 패턴을 찾는지 확인하는 테스트")
+    @Test
+    void findPattern3() {
+        // given
+        String text = "홍길동 hong@example.com";
+        // when
+        Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
+        // then
+        assertThat(result.getFirst()).isEqualTo("홍길동");
+        assertThat(result.getSecond()).isEqualTo("hong@example.com");
+    }
+}

--- a/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParserTest.java
+++ b/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParserTest.java
@@ -75,4 +75,16 @@ class NameAndEmailParserTest {
         assertThat(result.getFirst()).isEqualTo("홍길동 기자");
         assertThat(result.getSecond()).isEqualTo("hong@example.com");
     }
+
+    @Test
+    @DisplayName("홍길동기자 (이메일) 형식의 패턴을 찾는지 확인하는 테스트")
+    void findPattern6() {
+        // given
+        String text = "홍길동기자 (hong@example.com)";
+        // when
+        Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
+        // then
+        assertThat(result.getFirst()).isEqualTo("홍길동기자");
+        assertThat(result.getSecond()).isEqualTo("hong@example.com");
+    }
 }

--- a/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParserTest.java
+++ b/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/NameAndEmailParserTest.java
@@ -1,13 +1,11 @@
 package com.livefeed.livefeedbatch.batch.processor.parser.parser;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.util.Pair;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class NameAndEmailParserTest {
 
@@ -26,7 +24,7 @@ class NameAndEmailParserTest {
         // when
         Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
         // then
-        assertThat(result.getFirst()).isEqualTo("홍길동");
+        assertThat(result.getFirst()).isEqualTo("홍길동 기자");
         assertThat(result.getSecond()).isEqualTo("hong@example.com");
     }
 
@@ -38,7 +36,7 @@ class NameAndEmailParserTest {
         // when
         Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
         // then
-        assertThat(result.getFirst()).isEqualTo("홍길동");
+        assertThat(result.getFirst()).isEqualTo("홍길동 기자");
         assertThat(result.getSecond()).isEqualTo("hong@example.com");
     }
 
@@ -50,7 +48,31 @@ class NameAndEmailParserTest {
         // when
         Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
         // then
-        assertThat(result.getFirst()).isEqualTo("홍길동");
+        assertThat(result.getFirst()).isEqualTo("홍길동 기자");
+        assertThat(result.getSecond()).isEqualTo("hong@example.com");
+    }
+
+    @Test
+    @DisplayName("이름 언론사 기자(이메일) 형식의 패턴을 찾는지 확인하는 테스트")
+    void findPattern4() {
+        // given
+        String text = "홍길동 MK스포츠 기자(hong@example.com)";
+        // when
+        Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
+        // then
+        assertThat(result.getFirst()).isEqualTo("홍길동 MK스포츠 기자");
+        assertThat(result.getSecond()).isEqualTo("hong@example.com");
+    }
+
+    @Test
+    @DisplayName("이름 기자 (이메일) 형식의 패턴을 찾는지 확인하는 테스트")
+    void findPattern5() {
+        // given
+        String text = "홍길동 기자 (hong@example.com)";
+        // when
+        Pair<String, String> result = nameAndEmailParser.extractNameAndEmail(text);
+        // then
+        assertThat(result.getFirst()).isEqualTo("홍길동 기자");
         assertThat(result.getSecond()).isEqualTo("hong@example.com");
     }
 }


### PR DESCRIPTION
- 파싱 에러 수정 완료
    - 정규표현식을 이용하여 파싱하도록 수정
    - OOO 기자 라는 형식으로 DB에 저장하도록 수정

- RDB와 Elasticsearch 데이터 정합성 확인
    - DataSaver 도메인을 두고 해당 서비스를 트랜잭션으로 묶음

---

## 생각해볼 문제
- Redis 장애 문제
    - Redis가 죽었을때 로직 추가 필요
    - Redis가 죽었을때 단순히 이후 로직을 진행하면 데이터 중복 저장 문제가 발생할 수 있음

- 기자 이름이 너무 긴 문제
    - "OOO + 언론사 이름 + 기자" 형식으로 파싱되면 10글자가 넘는 경우가 발생할 수 있음
