### PR TITLE
[LF-55/bulk-insert] 엘라스틱서치 bulk 인서트로 변경

### DIFF
--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsWriter.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsWriter.java
@@ -3,13 +3,17 @@ package com.livefeed.livefeedbatch.batch.writer;
 import com.livefeed.livefeedbatch.batch.common.dto.ItemDto;
 import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
 import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.ParseResultDto;
+import com.livefeed.livefeedbatch.batch.domain.entity.Article;
 import com.livefeed.livefeedbatch.batch.writer.domain.DataSaver;
+import com.livefeed.livefeedbatch.batch.writer.elasticsearch.entity.ElasticsearchArticle;
+import com.livefeed.livefeedbatch.batch.writer.elasticsearch.repository.ArticleElasticsearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -18,19 +22,25 @@ import java.util.List;
 public class NewsWriter implements ItemWriter<ItemDto> {
 
     private final DataSaver dataSaver;
+    private final ArticleElasticsearchRepository articleElasticsearchRepository;
 
     @Override
     public void write(Chunk<? extends ItemDto> chunk) {
         List<? extends ItemDto> items = chunk.getItems();
+        List<ElasticsearchArticle> successItem = new ArrayList<>();
 
         for (ItemDto item : items) {
             UrlInfo key = item.urlInfo();
             ParseResultDto value = (ParseResultDto) item.itemDtoInterface().getValue();
             try {
-                dataSaver.saveArticle(key, value);
+                Article article = dataSaver.saveArticle(key, value);
+                ElasticsearchArticle elasticsearchArticle = ElasticsearchArticle.from(article, key, value);
+                successItem.add(elasticsearchArticle);
             } catch (Exception e) {
                 log.error("DB Exception Occur message = {} and Error Article Title = {}", e.getMessage(), value.url());
             }
         }
+        articleElasticsearchRepository.saveAll(successItem);
+        log.info("elasticsearch data save success, article count = {}", successItem.size());
     }
 }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/domain/DataSaver.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/domain/DataSaver.java
@@ -2,8 +2,6 @@ package com.livefeed.livefeedbatch.batch.writer.domain;
 
 import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
 import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.ParseResultDto;
-import com.livefeed.livefeedbatch.batch.writer.elasticsearch.entity.ElasticsearchArticle;
-import com.livefeed.livefeedbatch.batch.writer.elasticsearch.repository.ArticleElasticsearchRepository;
 import com.livefeed.livefeedbatch.batch.domain.entity.Article;
 import com.livefeed.livefeedbatch.batch.writer.rdb.service.RdbSaveService;
 import lombok.RequiredArgsConstructor;
@@ -18,16 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class DataSaver {
 
     private final RdbSaveService rdbSaveService;
-    private final ArticleElasticsearchRepository articleElasticsearchRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveArticle(UrlInfo key, ParseResultDto value) {
-        Article article = rdbSaveService.saveArticle(key, value);
-
-        log.info("saved article id = {}", article.getId());
-        ElasticsearchArticle elasticsearchArticle = ElasticsearchArticle.from(article, key, value);
-        articleElasticsearchRepository.save(elasticsearchArticle);
-        log.info("elasticsearch data save success, article id = {}", elasticsearchArticle.getId());
+    public Article saveArticle(UrlInfo key, ParseResultDto value) {
+        return rdbSaveService.saveArticle(key, value);
     }
-
 }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/config/PushgatewayConfiguration.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/config/PushgatewayConfiguration.java
@@ -8,14 +8,12 @@ import io.prometheus.client.exporter.PushGateway;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Profile("local")
-@Configuration
+//@Profile("local")
+//@Configuration
 @Slf4j
 public class PushgatewayConfiguration {
 


### PR DESCRIPTION
- 기존에 RDB에 저장한 row 별로 엘라스틱서치에 저장하던로직을 수정
- chunk 단위로 RDB 저장에 성공한 기사들을 list에 모아두었다가 한번에 bulk로 저장하도록 변경
- 배치 pushgateway는 우선 주석으로 빈등록 막음