### PR TITLE
[LF-59/connection-pool] 배치, 서비스 모듈 커넥션 풀 수정

### DIFF
--- a/LiveFeedBatch/build.gradle
+++ b/LiveFeedBatch/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = '0.2.7'
+version = '0.2.8'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
@@ -11,10 +11,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'io.prometheus:simpleclient_pushgateway'
-//    implementation ('com.oracle.database.jdbc:ojdbc11-production:21.1.0.0') {
-//        exclude group: 'com.oracle.database.ha', module: 'simplefan'
-//        exclude group: 'com.oracle.database.ha', module: 'ons'
-//    }
 
     runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
 

--- a/LiveFeedBatch/src/main/resources/application-prod.yaml
+++ b/LiveFeedBatch/src/main/resources/application-prod.yaml
@@ -8,12 +8,16 @@ spring:
       username: ${APP_DATABASE_USER}
       password: ${APP_DATABASE_PASSWORD}
       driver-class-name: oracle.jdbc.OracleDriver
+      configuration:
+        maximum-pool-size: ${APP_DATABASE_MAXIMUM_POOL_SIZE}
 
     batch:
       url: ${BATCH_DATABASE_URL}
       username: ${BATCH_DATABASE_USER}
       password: ${BATCH_DATABASE_PASSWORD}
       driver-class-name: oracle.jdbc.OracleDriver
+      configuration:
+        maximum-pool-size: ${BATCH_DATABASE_MAXIMUM_POOL_SIZE}
 
   data:
     redis:

--- a/LiveFeedService/build.gradle
+++ b/LiveFeedService/build.gradle
@@ -7,7 +7,7 @@ configurations {
     asciidoctorExt
 }
 
-version = '0.2.2'
+version = '0.2.3'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -16,10 +16,6 @@ dependencies {
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.jsoup:jsoup:1.16.2'
-//    implementation ('com.oracle.database.jdbc:ojdbc11-production:21.1.0.0') {
-//        exclude group: 'com.oracle.database.ha', module: 'simplefan'
-//        exclude group: 'com.oracle.database.ha', module: 'ons'
-//    }
 
     runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
     

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/LiveFeedServiceApplication.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/LiveFeedServiceApplication.java
@@ -2,8 +2,9 @@ package com.livefeed.livefeedservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRepositoriesAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = ReactiveElasticsearchRepositoriesAutoConfiguration.class)
 public class LiveFeedServiceApplication {
 
     public static void main(String[] args) {

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/common/util/SearchQueryMaker.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/common/util/SearchQueryMaker.java
@@ -78,6 +78,6 @@ public class SearchQueryMaker {
     }
 
     private void makeExplainQuery(NativeQueryBuilder nativeQueryBuilder) {
-        nativeQueryBuilder.withExplain(true);
+        nativeQueryBuilder.withExplain(false);
     }
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/elasticsearch/configuration/ElasticsearchClientConfig.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/elasticsearch/configuration/ElasticsearchClientConfig.java
@@ -6,9 +6,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 import java.util.List;
 
+@EnableElasticsearchRepositories(basePackages = "com.livefeed.livefeedservice.elasticsearch")
 @Configuration
 @RequiredArgsConstructor
 public class ElasticsearchClientConfig extends ElasticsearchConfiguration {

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/elasticsearch/entity/ElasticsearchArticle.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/elasticsearch/entity/ElasticsearchArticle.java
@@ -6,7 +6,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-@Document(indexName = "articles")
+@Document(indexName = "naver_articles", createIndex = false)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ElasticsearchArticle {

--- a/LiveFeedService/src/main/resources/application-prod.yaml
+++ b/LiveFeedService/src/main/resources/application-prod.yaml
@@ -7,6 +7,8 @@ spring:
     username: ${APP_DATABASE_USER}
     password: ${APP_DATABASE_PASSWORD}
     driver-class-name: oracle.jdbc.OracleDriver
+    hikari:
+      maximum-pool-size: ${APP_DATABASE_MAXIMUM_POOL_SIZE}
 
   jpa:
     hibernate:

--- a/http/LiveFeedService/articledetail/articledetail.http
+++ b/http/LiveFeedService/articledetail/articledetail.http
@@ -2,7 +2,7 @@
 GET http://localhost:8084/api/detail/articles/1
 
 ### 기사 목록을 전달하는 api
-GET http://localhost:8084/api/list/articles?type=bodyHtml,articleTitle&keyword=kt&size=3&sort=id-desc
+GET http://localhost:8084/api/list/articles?type=bodyHtml,headerHtml&keyword=hello&size=1&sort=id-desc
 #GET http://localhost:8084/api/list/articles?type=articleTitle&keyword=페이커&size=4&sort=id-desc
 
 ### search 쿼리가 아닌 api


### PR DESCRIPTION
- 배치 모듈 max-connection 2개로 수정
- 서비스 모듈 max-connection 5개로 수정
- service 모듈에서 elasticsearchRepository에서 rdb 관련 repository를 찾지 않도록 설정 변경
- elasticsearch의 search 쿼리에서 explain 설정 취소