### PR TITLE
[LF-66/elasticsearch-keyword] 사용자 요청 키워드 저장 및 이벤트 구현

### DIFF
--- a/LiveFeedBatch/build.gradle
+++ b/LiveFeedBatch/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = '0.2.8'
+version = '0.2.9'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/common/redis/configuration/RedisConfiguration.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/common/redis/configuration/RedisConfiguration.java
@@ -1,8 +1,10 @@
-package com.livefeed.livefeedbatch.batch.processor.redis.configuration;
+package com.livefeed.livefeedbatch.batch.common.redis.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,5 +33,10 @@ public class RedisConfiguration<K, V> {
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisConnection redisConnection() {
+        return redisConnectionFactory().getConnection();
     }
 }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/common/redis/operations/RedisOperations.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/common/redis/operations/RedisOperations.java
@@ -1,4 +1,4 @@
-package com.livefeed.livefeedbatch.batch.processor.redis.operations;
+package com.livefeed.livefeedbatch.batch.common.redis.operations;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/configuration/BatchConfiguration.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/configuration/BatchConfiguration.java
@@ -5,6 +5,7 @@ import com.livefeed.livefeedbatch.batch.common.converter.StringToUrlInfoConverte
 import com.livefeed.livefeedbatch.batch.common.converter.UrlInfoToStringConverter;
 import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
 import com.zaxxer.hikari.HikariDataSource;
+import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.converter.LocalDateTimeToStringConverter;
 import org.springframework.batch.core.converter.StringToLocalDateTimeConverter;
@@ -18,9 +19,10 @@ import org.springframework.core.convert.support.DefaultConversionService;
 
 @Configuration
 @EnableBatchProcessing(dataSourceRef = "batchDataSource", conversionServiceRef = "batchConversionService")
+@RequiredArgsConstructor
 public class BatchConfiguration {
-    // TODO: 2023/12/18 추후 하나의 객체로 통일
-    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     @ConfigurationProperties("spring.datasource.batch")

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/configuration/CommonConfiguration.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/configuration/CommonConfiguration.java
@@ -1,0 +1,16 @@
+package com.livefeed.livefeedbatch.batch.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class CommonConfiguration {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/launcher/CrawlJobLauncher.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/launcher/CrawlJobLauncher.java
@@ -1,9 +1,14 @@
 package com.livefeed.livefeedbatch.batch.launcher;
 
-import com.livefeed.livefeedbatch.batch.common.dto.keydto.*;
-import com.livefeed.livefeedbatch.batch.domain.repository.PageRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.Platform;
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.Service;
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.Theme;
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
 import com.livefeed.livefeedbatch.batch.domain.entity.Category;
 import com.livefeed.livefeedbatch.batch.domain.repository.CategoryRepository;
+import com.livefeed.livefeedbatch.batch.domain.repository.PageRepository;
+import com.livefeed.livefeedbatch.batch.util.NewArticleBucket;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.client.RestClient;
 import org.springframework.batch.core.Job;
@@ -11,8 +16,11 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -21,18 +29,26 @@ import java.time.LocalDateTime;
 @Component
 public class CrawlJobLauncher extends JobLauncherApplicationRunner {
 
+    @Value("${spring.redis-pub-sub.channel}")
+    private String channelTopic;
+
     private final Job naverNewsCrawlJob;
     private final PageRepository pageRepository;
     private final CategoryRepository categoryRepository;
     private final RestClient elasticsearchRestClient;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     public CrawlJobLauncher(JobLauncher jobLauncher, JobExplorer jobExplorer, JobRepository jobRepository, Job naverNewsCrawlJob,
-                            PageRepository pageRepository, CategoryRepository categoryRepository, RestClient elasticsearchRestClient) {
+                            PageRepository pageRepository, CategoryRepository categoryRepository,
+                            RestClient elasticsearchRestClient, ObjectMapper objectMapper, RedisTemplate<String, String> redisTemplate) {
         super(jobLauncher, jobExplorer, jobRepository);
         this.naverNewsCrawlJob = naverNewsCrawlJob;
         this.pageRepository = pageRepository;
         this.categoryRepository = categoryRepository;
         this.elasticsearchRestClient = elasticsearchRestClient;
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -40,6 +56,7 @@ public class CrawlJobLauncher extends JobLauncherApplicationRunner {
         UrlInfo urlInfo = new UrlInfo(Service.ARTICLE, Platform.NAVER, Theme.SPORTS);
         runCrawlJob(naverNewsCrawlJob, urlInfo);
         closeElasticSearchClient();
+        publishNewArticleIds();
     }
 
     private void runCrawlJob(Job job, UrlInfo urlInfo) {
@@ -65,9 +82,20 @@ public class CrawlJobLauncher extends JobLauncherApplicationRunner {
 
     private void closeElasticSearchClient() {
         try {
-           elasticsearchRestClient.close();
+            log.info("close elasticsearch client");
+            elasticsearchRestClient.close();
         } catch (Exception e) {
             log.error("Failed to close elasticsearch client.", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void publishNewArticleIds() {
+        try {
+            Long count = redisTemplate.convertAndSend(ChannelTopic.of(channelTopic).getTopic(), objectMapper.writeValueAsString(NewArticleBucket.getNewArticleIds()));
+            log.info("success publish new article ids to publish = {}", count);
+        } catch (Exception e) {
+            log.error("Failed to publish new article ids to redis ", e);
             throw new RuntimeException(e);
         }
     }

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/NaverNewsContentProcessor.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/NaverNewsContentProcessor.java
@@ -4,7 +4,7 @@ import com.livefeed.livefeedbatch.batch.common.dto.ItemDto;
 import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
 import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.ParseResultDto;
 import com.livefeed.livefeedbatch.batch.processor.parser.ParserProvider;
-import com.livefeed.livefeedbatch.batch.processor.redis.operations.RedisOperations;
+import com.livefeed.livefeedbatch.batch.common.redis.operations.RedisOperations;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/Parser.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/Parser.java
@@ -12,7 +12,7 @@ import org.openqa.selenium.WebDriver;
 @Slf4j
 public abstract class Parser {
 
-    protected final String OUTER_HTML = "outerHTML";
+    protected static final String OUTER_HTML = "outerHTML";
 
     public ParseResultDto parseWebPage(String url) {
         WebDriver driver = ChromeDriverProvider.getDriver();
@@ -29,6 +29,11 @@ public abstract class Parser {
 
     private ParseResultDto parse(String url, WebDriver driver) {
         driver.get(url);
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         HeaderDto headerDto = parseHeader(driver);
         BodyDto bodyDto = parseBody(driver);
         return ParseResultDto.from(url, headerDto, bodyDto);

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/orderParser/OrderVersionNaverSportsParser.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/orderParser/OrderVersionNaverSportsParser.java
@@ -1,0 +1,83 @@
+package com.livefeed.livefeedbatch.batch.processor.parser.parser.orderParser;
+
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.Platform;
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.Theme;
+import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
+import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.BodyDto;
+import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.HeaderDto;
+import com.livefeed.livefeedbatch.batch.processor.parser.parser.NameAndEmailParser;
+import com.livefeed.livefeedbatch.batch.processor.parser.parser.Parser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.springframework.data.util.Pair;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OrderVersionNaverSportsParser extends Parser {
+
+    private final Platform platform = Platform.NAVER;
+    private final Theme theme = Theme.SPORTS;
+
+    private static final Header header = Header.SPORTS;
+    private static final Body body = Body.SPORTS;
+
+
+    private final NameAndEmailParser nameAndEmailParser;
+
+    @Override
+    protected HeaderDto parseHeader(WebDriver driver) {
+        WebElement webElement = driver.findElement(By.cssSelector(header.innerHtml));
+
+        String html = webElement.getAttribute(OUTER_HTML);
+        String articleTitle = webElement.findElement(By.cssSelector(header.articleTitle)).getText();
+        String pressCompanyName = webElement.findElement(By.cssSelector(header.pressCompanyName)).getAttribute("alt");
+        String publicationTime = webElement.findElement(By.cssSelector(header.publicationTime)).getText();
+        String originArticleUrl = webElement.findElement(By.cssSelector(header.originArticleUrl)).getAttribute("href");
+
+        return HeaderDto.of(html, articleTitle, pressCompanyName, publicationTime, originArticleUrl);
+    }
+
+    @Override
+    protected BodyDto parseBody(WebDriver driver) {
+        WebElement webElement = driver.findElement(By.cssSelector(body.innerHtml));
+
+        String htmlTemp = webElement.getAttribute(OUTER_HTML);
+        String html = getHtml(htmlTemp);
+        String journalistNameAndEmail = webElement.findElement(By.cssSelector(body.journalistNameAndEmail)).getText();
+        Pair<String, String> nameEmailPair = nameAndEmailParser.extractNameAndEmail(journalistNameAndEmail);
+
+        return BodyDto.of(html, nameEmailPair.getFirst(), nameEmailPair.getSecond());
+    }
+
+    @Override
+    public boolean support(UrlInfo key) {
+        return key.platform() == platform && key.theme() == theme;
+    }
+
+    private String getHtml(String htmlTemp) {
+        int index = htmlTemp.indexOf("<div class=\"reporter_area\"");
+        return htmlTemp.substring(0, index) + "</div>";
+    }
+
+    @RequiredArgsConstructor
+    private enum Header {
+        SPORTS("div.news_headline", "span#pressLogo img", "h4.title", "div.info span:nth-child(1)", "div.info a");
+
+        private final String innerHtml;
+        private final String pressCompanyName;
+        private final String articleTitle;
+        private final String publicationTime;
+        private final String originArticleUrl;
+    }
+
+    @RequiredArgsConstructor
+    private enum Body {
+        SPORTS("div#newsEndContents", "p.byline");
+
+        private final String innerHtml;
+        private final String journalistNameAndEmail;
+    }
+}

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/util/NewArticleBucket.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/util/NewArticleBucket.java
@@ -1,0 +1,17 @@
+package com.livefeed.livefeedbatch.batch.util;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class NewArticleBucket {
+
+    private static final List<Long> newArticleIds = new CopyOnWriteArrayList<>();
+
+    public static void add(Long articleId) {
+        newArticleIds.add(articleId);
+    }
+
+    public static List<Long> getNewArticleIds() {
+        return newArticleIds;
+    }
+}

--- a/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsWriter.java
+++ b/LiveFeedBatch/src/main/java/com/livefeed/livefeedbatch/batch/writer/NewsWriter.java
@@ -4,6 +4,7 @@ import com.livefeed.livefeedbatch.batch.common.dto.ItemDto;
 import com.livefeed.livefeedbatch.batch.common.dto.keydto.UrlInfo;
 import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.ParseResultDto;
 import com.livefeed.livefeedbatch.batch.domain.entity.Article;
+import com.livefeed.livefeedbatch.batch.util.NewArticleBucket;
 import com.livefeed.livefeedbatch.batch.writer.domain.DataSaver;
 import com.livefeed.livefeedbatch.batch.writer.elasticsearch.entity.ElasticsearchArticle;
 import com.livefeed.livefeedbatch.batch.writer.elasticsearch.repository.ArticleElasticsearchRepository;
@@ -36,6 +37,7 @@ public class NewsWriter implements ItemWriter<ItemDto> {
                 Article article = dataSaver.saveArticle(key, value);
                 ElasticsearchArticle elasticsearchArticle = ElasticsearchArticle.from(article, key, value);
                 successItem.add(elasticsearchArticle);
+                NewArticleBucket.add(article.getId());
             } catch (Exception e) {
                 log.error("DB Exception Occur message = {} and Error Article Title = {}", e.getMessage(), value.url());
             }

--- a/LiveFeedBatch/src/main/resources/application-prod.yaml
+++ b/LiveFeedBatch/src/main/resources/application-prod.yaml
@@ -19,6 +19,9 @@ spring:
       configuration:
         maximum-pool-size: ${BATCH_DATABASE_MAXIMUM_POOL_SIZE}
 
+  redis-pub-sub:
+    channel: ${REDIS_PUB_SUB_CHANNEL}
+
   data:
     redis:
       repositories:

--- a/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/OrderVersionNaverSportsParserTest.java
+++ b/LiveFeedBatch/src/test/java/com/livefeed/livefeedbatch/batch/processor/parser/parser/OrderVersionNaverSportsParserTest.java
@@ -1,0 +1,23 @@
+package com.livefeed.livefeedbatch.batch.processor.parser.parser;
+
+import com.livefeed.livefeedbatch.batch.common.dto.processorvaluedto.ParseResultDto;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class OrderVersionNaverSportsParserTest {
+
+
+    @Test
+    @DisplayName("")
+    void parse() {
+        // given
+        NaverSportsParser naverSportsParser = new NaverSportsParser(new NameAndEmailParser());
+        // when
+        ParseResultDto result = naverSportsParser.parseWebPage("https://m.sports.naver.com/general/article/052/0002029306");
+        // then
+        log.info("result = {}", result);
+    }
+
+}

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/controller/ArticleListController.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/controller/ArticleListController.java
@@ -6,10 +6,7 @@ import com.livefeed.livefeedservice.common.dto.SuccessResponse;
 import com.livefeed.livefeedservice.articlelist.util.SearchQueryParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,12 +26,13 @@ public class ArticleListController {
             @RequestParam(value = "lastScore", required = false) Double lastScore,
             @RequestParam(value = "lastId", required = false) Long lastArticleId,
             @RequestParam(value = "pit", required = false) String pit,
-            @RequestParam(value = "related", required = false, defaultValue = "false") boolean isRelatedQuery
-            ) {
+            @RequestParam(value = "related", required = false, defaultValue = "false") boolean isRelatedQuery,
+            @CookieValue("sseKey") String sseKey
+    ) {
 
         SearchQueryParam searchQueryParam = SearchQueryParam.makeParam(type, keywords, size, lastScore, lastArticleId, pit, isRelatedQuery);
-        log.info("search article list controller, search param = {}", searchQueryParam);
-        ArticleListDto data = articleListService.getArticleList(searchQueryParam);
+        log.info("search article list controller, search param = {}, sseKey = {}", searchQueryParam, sseKey);
+        ArticleListDto data = articleListService.getArticleList(searchQueryParam, sseKey);
 
         return SuccessResponse.ok("기사 목록 조회 성공했습니다.", data);
     }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/dto/ArticleListDto.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/dto/ArticleListDto.java
@@ -10,9 +10,15 @@ public record ArticleListDto(
         String pit
 ) {
 
-    public static ArticleListDto of(List<ArticleDto> articles, boolean isLast, Float lastScore, Long lastId, String pit) {
+    public static ArticleListDto from(SearchResultDto searchResultDto, int pageSize) {
+        List<ArticleDto> articleList = searchResultDto.articleDtoList();
+
         return new ArticleListDto(
-                articles, isLast, lastScore, lastId, pit
+                articleList,
+                articleList.size() < pageSize,
+                articleList.size() > 0 ? articleList.get(articleList.size() - 1).score() : null,
+                articleList.size() > 0 ? articleList.get(articleList.size() - 1).articleId() : null,
+                searchResultDto.pit()
         );
     }
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/dto/KeywordEvent.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/dto/KeywordEvent.java
@@ -1,0 +1,8 @@
+package com.livefeed.livefeedservice.articlelist.dto;
+
+import java.util.List;
+
+public record KeywordEvent(
+        List<String> keywords
+) {
+}

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/dto/SearchResultDto.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/dto/SearchResultDto.java
@@ -1,0 +1,9 @@
+package com.livefeed.livefeedservice.articlelist.dto;
+
+import java.util.List;
+
+public record SearchResultDto(
+        List<ArticleDto> articleDtoList,
+        String pit
+) {
+}

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/repository/NativeQueryElasticsearchOperations.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/repository/NativeQueryElasticsearchOperations.java
@@ -3,6 +3,10 @@ package com.livefeed.livefeedservice.articlelist.repository;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch.core.OpenPointInTimeResponse;
+import com.livefeed.livefeedservice.articlelist.domain.SearchHitModifier;
+import com.livefeed.livefeedservice.articlelist.dto.ArticleDto;
+import com.livefeed.livefeedservice.articlelist.dto.ModifiedSearchResultDto;
+import com.livefeed.livefeedservice.articlelist.dto.SearchResultDto;
 import com.livefeed.livefeedservice.articlelist.util.QueryMaker;
 import com.livefeed.livefeedservice.articlelist.util.SearchQueryParam;
 import com.livefeed.livefeedservice.common.exception.UnableToGetPitException;
@@ -10,8 +14,11 @@ import com.livefeed.livefeedservice.elasticsearch.entity.ElasticsearchArticle;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 
 @Repository
@@ -21,6 +28,7 @@ public class NativeQueryElasticsearchOperations implements SearchOperations {
     private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticsearchClient elasticsearchClient;
     private final QueryMaker queryMaker;
+    private final SearchHitModifier searchHitModifier;
 
     private final String PIT_EXIST_TIME = "5m";
 
@@ -36,8 +44,49 @@ public class NativeQueryElasticsearchOperations implements SearchOperations {
     }
 
     @Override
-    public SearchHits<ElasticsearchArticle> getSearchResult(SearchQueryParam searchQueryParam) {
+    public SearchResultDto getSearchResultTemp(SearchQueryParam searchQueryParam) {
         NativeQuery nativeQuery = queryMaker.makeArticleListQuery(searchQueryParam);
-        return elasticsearchOperations.search(nativeQuery, ElasticsearchArticle.class);
+        SearchHits<ElasticsearchArticle> searchHits = elasticsearchOperations.search(nativeQuery, ElasticsearchArticle.class);
+
+        List<ArticleDto> articleDtoList = makeArticleDtoList(searchHits);
+        String pit = searchHits.getPointInTimeId();
+
+        return new SearchResultDto(articleDtoList, pit);
+    }
+
+    private List<ArticleDto> makeArticleDtoList(SearchHits<ElasticsearchArticle> searchResult) {
+        return searchResult.getSearchHits().stream().map(search -> {
+            ModifiedSearchResultDto modifiedArticle = extractSearchResult(search);
+            return new ArticleDto(
+                    search.getContent().getId(),
+                    modifiedArticle.articleTitle(),
+                    search.getContent().getPressCompanyName(),
+                    modifiedArticle.articleBody(),
+                    modifiedArticle.articleImg(),
+                    search.getContent().getPublicationTime(),
+                    search.getScore()
+            );
+        }).toList();
+    }
+
+    private ModifiedSearchResultDto extractSearchResult(SearchHit<ElasticsearchArticle> search) {
+        String articleTitle;
+        List<String> headerHtmlHighLights = search.getHighlightField("articleTitle");
+        if (headerHtmlHighLights.size() == 0) {
+            articleTitle = search.getContent().getArticleTitle();
+        } else {
+            articleTitle = headerHtmlHighLights.get(0);
+        }
+
+        String articleBody;
+        List<String> bodyHtmlHighLights = search.getHighlightField("bodyHtml");
+        if (bodyHtmlHighLights.size() == 0) {
+            articleBody = searchHitModifier.extractTextFromHtml(search.getContent().getBodyHtml());
+        } else {
+            articleBody = searchHitModifier.extractTagExceptBoldTag(bodyHtmlHighLights.get(0));
+        }
+
+        String articleImg = searchHitModifier.extractFirstImgFromHtml(search.getContent().getBodyHtml());
+        return new ModifiedSearchResultDto(articleTitle, articleImg, articleBody);
     }
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/repository/SearchOperations.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/repository/SearchOperations.java
@@ -1,5 +1,6 @@
 package com.livefeed.livefeedservice.articlelist.repository;
 
+import com.livefeed.livefeedservice.articlelist.dto.SearchResultDto;
 import com.livefeed.livefeedservice.articlelist.util.SearchQueryParam;
 import com.livefeed.livefeedservice.elasticsearch.entity.ElasticsearchArticle;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -8,5 +9,5 @@ public interface SearchOperations {
 
     String getPit(String indexName);
 
-    SearchHits<ElasticsearchArticle> getSearchResult(SearchQueryParam searchQueryParam);
+    SearchResultDto getSearchResultTemp(SearchQueryParam searchQueryParam);
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
@@ -1,6 +1,7 @@
 package com.livefeed.livefeedservice.articlelist.service;
 
 import com.livefeed.livefeedservice.articlelist.dto.ArticleListDto;
+import com.livefeed.livefeedservice.articlelist.dto.KeywordEvent;
 import com.livefeed.livefeedservice.articlelist.dto.SearchResultDto;
 import com.livefeed.livefeedservice.articlelist.repository.SearchOperations;
 import com.livefeed.livefeedservice.articlelist.util.SearchQueryParam;
@@ -16,6 +17,7 @@ public class ArticleListService {
 
     private final SearchOperations searchOperations;
     private final UserKeywordRepository userKeywordRepository;
+    private final KeywordEventPublisher eventPublisher;
 
     private static final String ARTICLE_INDEX_NAME = "articles";
 
@@ -33,7 +35,7 @@ public class ArticleListService {
         log.info("update keyword count = {}", updateCount);
 
         if (updateCount != 0) {
-            // 이벤트 발행
+            eventPublisher.publishKeywordEvent(new KeywordEvent(searchQueryParam.getKeywords()));
         }
 
         return ArticleListDto.from(searchResultDto, searchQueryParam.getSize());

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
@@ -17,7 +17,7 @@ public class ArticleListService {
 
     private static final String ARTICLE_INDEX_NAME = "articles";
 
-    public ArticleListDto getArticleList(SearchQueryParam searchQueryParam) {
+    public ArticleListDto getArticleList(SearchQueryParam searchQueryParam, String sseKey) {
         // pit가 설정이 안되어 있는 경우 pit를 먼저 가져온다.
         if (isFirstSearchRequest(searchQueryParam)) {
             searchQueryParam.setFirstRequestPit(searchOperations.getPit(ARTICLE_INDEX_NAME));
@@ -25,6 +25,10 @@ public class ArticleListService {
 
         // TODO: 12/10/23 엘라스틱서치 내부에서 에러가 발생하는 경우도 체크할 필요가 있음
         SearchResultDto searchResultDto = searchOperations.getSearchResultTemp(searchQueryParam);
+
+        // 사용자 검색 결과를 redis에 저장해야함
+
+
         return ArticleListDto.from(searchResultDto, searchQueryParam.getSize());
     }
 

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
@@ -4,6 +4,7 @@ import com.livefeed.livefeedservice.articlelist.dto.ArticleListDto;
 import com.livefeed.livefeedservice.articlelist.dto.SearchResultDto;
 import com.livefeed.livefeedservice.articlelist.repository.SearchOperations;
 import com.livefeed.livefeedservice.articlelist.util.SearchQueryParam;
+import com.livefeed.livefeedservice.newarticle.repository.UserKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class ArticleListService {
 
     private final SearchOperations searchOperations;
+    private final UserKeywordRepository userKeywordRepository;
 
     private static final String ARTICLE_INDEX_NAME = "articles";
 
@@ -27,7 +29,12 @@ public class ArticleListService {
         SearchResultDto searchResultDto = searchOperations.getSearchResultTemp(searchQueryParam);
 
         // 사용자 검색 결과를 redis에 저장해야함
+        int updateCount = userKeywordRepository.updateUserKeywords(sseKey, searchQueryParam.getKeywords());
+        log.info("update keyword count = {}", updateCount);
 
+        if (updateCount != 0) {
+            // 이벤트 발행
+        }
 
         return ArticleListDto.from(searchResultDto, searchQueryParam.getSize());
     }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/ArticleListService.java
@@ -1,88 +1,34 @@
 package com.livefeed.livefeedservice.articlelist.service;
 
-import com.livefeed.livefeedservice.articlelist.domain.SearchHitModifier;
-import com.livefeed.livefeedservice.articlelist.dto.ArticleDto;
 import com.livefeed.livefeedservice.articlelist.dto.ArticleListDto;
-import com.livefeed.livefeedservice.articlelist.dto.ModifiedSearchResultDto;
-import com.livefeed.livefeedservice.articlelist.repository.NativeQueryElasticsearchOperations;
+import com.livefeed.livefeedservice.articlelist.dto.SearchResultDto;
+import com.livefeed.livefeedservice.articlelist.repository.SearchOperations;
 import com.livefeed.livefeedservice.articlelist.util.SearchQueryParam;
-import com.livefeed.livefeedservice.elasticsearch.entity.ElasticsearchArticle;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.elasticsearch.core.SearchHit;
-import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ArticleListService {
 
-    private final NativeQueryElasticsearchOperations nativeQueryElasticsearchRepository;
-    private final SearchHitModifier searchHitModifier;
+    private final SearchOperations searchOperations;
 
     private static final String ARTICLE_INDEX_NAME = "articles";
 
     public ArticleListDto getArticleList(SearchQueryParam searchQueryParam) {
         // pit가 설정이 안되어 있는 경우 pit를 먼저 가져온다.
         if (isFirstSearchRequest(searchQueryParam)) {
-            searchQueryParam.setFirstRequestPit(nativeQueryElasticsearchRepository.getPit(ARTICLE_INDEX_NAME));
+            searchQueryParam.setFirstRequestPit(searchOperations.getPit(ARTICLE_INDEX_NAME));
         }
 
         // TODO: 12/10/23 엘라스틱서치 내부에서 에러가 발생하는 경우도 체크할 필요가 있음
-        SearchHits<ElasticsearchArticle> searchResult = nativeQueryElasticsearchRepository.getSearchResult(searchQueryParam);
-        String pit = searchResult.getPointInTimeId();
-
-        List<ArticleDto> articleList = makeArticleDtoList(searchResult);
-
-        return ArticleListDto.of(
-                articleList,
-                articleList.size() < searchQueryParam.getSize(),
-                articleList.size() > 0 ? articleList.get(articleList.size() - 1).score() : null,
-                articleList.size() > 0 ? articleList.get(articleList.size() - 1).articleId() : null,
-                pit
-        );
+        SearchResultDto searchResultDto = searchOperations.getSearchResultTemp(searchQueryParam);
+        return ArticleListDto.from(searchResultDto, searchQueryParam.getSize());
     }
 
     private boolean isFirstSearchRequest(SearchQueryParam searchQueryParam) {
         return searchQueryParam.getPit() == null || searchQueryParam.getPit().isEmpty();
-    }
-
-    private List<ArticleDto> makeArticleDtoList(SearchHits<ElasticsearchArticle> searchResult) {
-        return searchResult.getSearchHits().stream().map(search -> {
-            ModifiedSearchResultDto modifiedArticle = extractSearchResult(search);
-            return new ArticleDto(
-                    search.getContent().getId(),
-                    modifiedArticle.articleTitle(),
-                    search.getContent().getPressCompanyName(),
-                    modifiedArticle.articleBody(),
-                    modifiedArticle.articleImg(),
-                    search.getContent().getPublicationTime(),
-                    search.getScore()
-            );
-        }).toList();
-    }
-
-    private ModifiedSearchResultDto extractSearchResult(SearchHit<ElasticsearchArticle> search) {
-        String articleTitle;
-        List<String> headerHtmlHighLights = search.getHighlightField("articleTitle");
-        if (headerHtmlHighLights.size() == 0) {
-            articleTitle = search.getContent().getArticleTitle();
-        } else {
-            articleTitle = headerHtmlHighLights.get(0);
-        }
-
-        String articleBody;
-        List<String> bodyHtmlHighLights = search.getHighlightField("bodyHtml");
-        if (bodyHtmlHighLights.size() == 0) {
-            articleBody = searchHitModifier.extractTextFromHtml(search.getContent().getBodyHtml());
-        } else {
-            articleBody = searchHitModifier.extractTagExceptBoldTag(bodyHtmlHighLights.get(0));
-        }
-
-        String articleImg = searchHitModifier.extractFirstImgFromHtml(search.getContent().getBodyHtml());
-        return new ModifiedSearchResultDto(articleTitle, articleImg, articleBody);
     }
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/KeywordEventPublisher.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/service/KeywordEventPublisher.java
@@ -1,0 +1,20 @@
+package com.livefeed.livefeedservice.articlelist.service;
+
+import com.livefeed.livefeedservice.articlelist.dto.KeywordEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KeywordEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publishKeywordEvent(KeywordEvent keywordEvent) {
+        log.info("keywordEvent = {}", keywordEvent);
+        eventPublisher.publishEvent(keywordEvent);
+    }
+}

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/util/QueryMaker.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/articlelist/util/QueryMaker.java
@@ -19,18 +19,14 @@ public class QueryMaker {
 
     private final int PIT_DURATION_MINUTES = 3;
 
-    public boolean isRightQueryMaker(SearchQueryParam searchQueryParam) {
-        return true;
-    }
-
     public NativeQuery makeArticleListQuery(SearchQueryParam searchQueryParam) {
         NativeQueryBuilder nativeQueryBuilder = NativeQuery.builder();
 
         if (isShouldSearchQuery(searchQueryParam)) {
             makeShouldQuery(nativeQueryBuilder, searchQueryParam.getType(), searchQueryParam.getKeywords());
+            makeHighlightQuery(nativeQueryBuilder, searchQueryParam.getType());
         }
 
-        makeHighlightQuery(nativeQueryBuilder, searchQueryParam.getType());
         makeQuerySize(nativeQueryBuilder, searchQueryParam.getSize());
         makeSortQuery(nativeQueryBuilder, searchQueryParam.getSort());
         makeSearchAfterQuery(nativeQueryBuilder, searchQueryParam.getLastScore(), searchQueryParam.getLastId());

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/common/configuration/RedisConfiguration.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/common/configuration/RedisConfiguration.java
@@ -1,4 +1,4 @@
-package com.livefeed.livefeedservice.newarticle.config;
+package com.livefeed.livefeedservice.common.configuration;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +18,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class RedisConfig {
+public class RedisConfiguration {
 
     @Value("${spring.redis-pub-sub.channel}")
     private String channelTopic;

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/domain/Emitters.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/domain/Emitters.java
@@ -55,6 +55,10 @@ public class Emitters {
     public void sendAlertMessage(Set<String> terms, Map<String, Set<String>> userKeywordMap) {
         for (String sseKey : userKeywordMap.keySet()) {
             Set<String> keywords = userKeywordMap.get(sseKey);
+            if (keywords == null) {
+                return;
+            }
+
             for (String keyword : keywords) {
                 if (terms.contains(keyword)) {
                     sendAlertMessage(sseKey);

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepository.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 @Repository
@@ -17,5 +19,16 @@ public class RedisUserKeywordRepository implements UserKeywordRepository {
     public Set<String> getUserKeywords(String sseKey) {
         SetOperations<String, String> setOperations = redisTemplate.opsForSet();
         return setOperations.members(sseKey);
+    }
+
+    @Override
+    public Long setUserKeywords(String sseKey, List<String> keywords) {
+        SetOperations<String, String> setOperations = redisTemplate.opsForSet();
+
+        if (keywords != null && !keywords.isEmpty()) {
+            String[] keywordArray = keywords.toArray(new String[0]);
+            return setOperations.add(sseKey, keywordArray);
+        }
+        return 0L;
     }
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepository.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepository.java
@@ -5,8 +5,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Repository;
 
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Repository
@@ -22,13 +23,52 @@ public class RedisUserKeywordRepository implements UserKeywordRepository {
     }
 
     @Override
-    public Long setUserKeywords(String sseKey, List<String> keywords) {
-        SetOperations<String, String> setOperations = redisTemplate.opsForSet();
+    public int updateUserKeywords(String sseKey, List<String> newKeywords) {
+        int changeWordsCount = 0;
 
-        if (keywords != null && !keywords.isEmpty()) {
-            String[] keywordArray = keywords.toArray(new String[0]);
-            return setOperations.add(sseKey, keywordArray);
+        SetOperations<String, String> setOperations = redisTemplate.opsForSet();
+        Set<String> existedKeywords = getUserKeywords(sseKey);
+
+        if (existedKeywords.isEmpty() && newKeywords.isEmpty()) {
+            return 0;
         }
-        return 0L;
+
+        if (existedKeywords.isEmpty()) {
+            return Objects.requireNonNull(setOperations.add(sseKey, newKeywords.toArray(new String[0]))).intValue();
+        }
+
+        changeWordsCount += addKeywordsCount(sseKey, newKeywords, setOperations, existedKeywords);
+        changeWordsCount += removeKeywordsCount(sseKey, newKeywords, setOperations, existedKeywords);
+
+        return changeWordsCount;
+    }
+
+    @Override
+    public void deleteUserKeywords(String sseKey) {
+        SetOperations<String, String> setOperations = redisTemplate.opsForSet();
+        Set<String> existedKeywords = getUserKeywords(sseKey);
+        if (!existedKeywords.isEmpty()) {
+            setOperations.remove(sseKey, (Object[]) existedKeywords.toArray(new String[0]));
+        }
+    }
+
+    private int addKeywordsCount(String sseKey, List<String> keywords, SetOperations<String, String> setOperations, Set<String> existedKeywords) {
+        Set<String> toAddKeywords = new HashSet<>(keywords);
+        toAddKeywords.removeAll(existedKeywords);
+
+        if (!toAddKeywords.isEmpty()) {
+            return Objects.requireNonNull(setOperations.add(sseKey, toAddKeywords.toArray(new String[0]))).intValue();
+        }
+        return 0;
+    }
+
+    private int removeKeywordsCount(String sseKey, List<String> keywords, SetOperations<String, String> setOperations, Set<String> existedKeywords) {
+        Set<String> toRemoveKeywords = new HashSet<>(existedKeywords);
+        keywords.forEach(toRemoveKeywords::remove);
+
+        if (!toRemoveKeywords.isEmpty()) {
+            return Objects.requireNonNull(setOperations.remove(sseKey, (Object[]) toRemoveKeywords.toArray(new String[0]))).intValue();
+        }
+        return 0;
     }
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/UserKeywordRepository.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/UserKeywordRepository.java
@@ -1,8 +1,11 @@
 package com.livefeed.livefeedservice.newarticle.repository;
 
+import java.util.List;
 import java.util.Set;
 
 public interface UserKeywordRepository {
 
     Set<String> getUserKeywords(String sseKey);
+
+    Long setUserKeywords(String sseKey, List<String> keywords);
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/UserKeywordRepository.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/repository/UserKeywordRepository.java
@@ -7,5 +7,7 @@ public interface UserKeywordRepository {
 
     Set<String> getUserKeywords(String sseKey);
 
-    Long setUserKeywords(String sseKey, List<String> keywords);
+    int updateUserKeywords(String sseKey, List<String> newKeywords);
+
+    void deleteUserKeywords(String sseKey);
 }

--- a/LiveFeedService/src/main/resources/application-prod.yaml
+++ b/LiveFeedService/src/main/resources/application-prod.yaml
@@ -19,6 +19,7 @@ spring:
       hibernate:
         show_sql: false
         format_sql: false
+    open-in-view: false
 
   data:
     redis:

--- a/LiveFeedService/src/test/java/com/livefeed/livefeedservice/articlelist/controller/ArticleListControllerTest.java
+++ b/LiveFeedService/src/test/java/com/livefeed/livefeedservice/articlelist/controller/ArticleListControllerTest.java
@@ -61,7 +61,7 @@ class ArticleListControllerTest {
 
         ArticleListDto data = ArticleListDto.from(searchResultDto, 2);
 
-        Mockito.doReturn(data).when(articleListService).getArticleList(Mockito.any(SearchQueryParam.class));
+        Mockito.doReturn(data).when(articleListService).getArticleList(Mockito.any(SearchQueryParam.class), Mockito.any());
 
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get(url)

--- a/LiveFeedService/src/test/java/com/livefeed/livefeedservice/articlelist/controller/ArticleListControllerTest.java
+++ b/LiveFeedService/src/test/java/com/livefeed/livefeedservice/articlelist/controller/ArticleListControllerTest.java
@@ -2,6 +2,7 @@ package com.livefeed.livefeedservice.articlelist.controller;
 
 import com.livefeed.livefeedservice.articlelist.dto.ArticleDto;
 import com.livefeed.livefeedservice.articlelist.dto.ArticleListDto;
+import com.livefeed.livefeedservice.articlelist.dto.SearchResultDto;
 import com.livefeed.livefeedservice.articlelist.service.ArticleListService;
 import com.livefeed.livefeedservice.articlelist.util.SearchQueryParam;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,16 +54,12 @@ class ArticleListControllerTest {
     @DisplayName("search 쿼리를 통해 기사를 검색할 수 있습니다.")
     void getArticleList() throws Exception {
         // given
-        ArticleListDto data = ArticleListDto.of(
-                List.of(
-                        new ArticleDto(5L, "article5", "press5", "content5", "photo5", "5분전", 0f),
-                        new ArticleDto(3L, "article3", "press3", "content3", "photo3", "3분전", 0f)
-                ),
-                false,
-                0f,
-                3L,
-                "3eaGBAEIYXJ0aWNsZXMWOVpGTDhfYTh"
-        );
+        SearchResultDto searchResultDto = new SearchResultDto(List.of(
+                new ArticleDto(5L, "article5", "press5", "content5", "photo5", "5분전", 0f),
+                new ArticleDto(3L, "article3", "press3", "content3", "photo3", "3분전", 0f)
+        ), "3eaGBAEIYXJ0aWNsZXMWOVpGTDhfYTh");
+
+        ArticleListDto data = ArticleListDto.from(searchResultDto, 2);
 
         Mockito.doReturn(data).when(articleListService).getArticleList(Mockito.any(SearchQueryParam.class));
 
@@ -99,35 +96,5 @@ class ArticleListControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("data.isLast").value(false))
                 .andExpect(MockMvcResultMatchers.jsonPath("data.lastId").value(3L))
                 .andExpect(MockMvcResultMatchers.jsonPath("data.pit").value("3eaGBAEIYXJ0aWNsZXMWOVpGTDhfYTh"));
-//                .andDo(
-//                        MockMvcRestDocumentation.document("article-list",
-//                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
-//                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
-//                                RequestDocumentation.queryParameters(
-//                                        RequestDocumentation.parameterWithName("type").description("제목/본문 어디서 검색할지에 대한 조건").optional(),
-//                                        RequestDocumentation.parameterWithName("keyword").description("검색하고자 하는 키워드").optional(),
-//                                        RequestDocumentation.parameterWithName("size").description("한번에 검색하는 목록 개수").optional(),
-//                                        RequestDocumentation.parameterWithName("sort").description("정렬 기준 (id-desc)").optional(),
-//                                        RequestDocumentation.parameterWithName("lastId").description("마지막으로 조회된 기사 id 값").optional(),
-//                                        RequestDocumentation.parameterWithName("pit").description("기존 검색에서 전달받은 pit 값").optional()
-//                                ),
-//                                PayloadDocumentation.responseFields(
-//                                        PayloadDocumentation.fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
-//                                        PayloadDocumentation.fieldWithPath("status").type(JsonFieldType.NUMBER).description("상태값"),
-//                                        PayloadDocumentation.fieldWithPath("message").type(JsonFieldType.STRING).description("상세 메시지"),
-//                                        PayloadDocumentation.fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
-//                                        PayloadDocumentation.fieldWithPath("data.articles[0].articleId").type(JsonFieldType.NUMBER).description("기사 아이디"),
-//                                        PayloadDocumentation.fieldWithPath("data.articles[0].title").type(JsonFieldType.STRING).description("기사 제목"),
-//                                        PayloadDocumentation.fieldWithPath("data.articles[0].pressCompany").type(JsonFieldType.STRING).description("언론사 이름"),
-//                                        PayloadDocumentation.fieldWithPath("data.articles[0].content").type(JsonFieldType.STRING).description("기사 본문"),
-//                                        PayloadDocumentation.fieldWithPath("data.articles[0].photo").type(JsonFieldType.STRING).description("기사의 첫 번째 사진"),
-//                                        PayloadDocumentation.fieldWithPath("data.articles[0].minutesAgo").type(JsonFieldType.STRING).description("기사의 발행 시간"),
-//                                        PayloadDocumentation.fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN).description("마지막 페이지인지 여부"),
-//                                        PayloadDocumentation.fieldWithPath("data.lastId").type(JsonFieldType.NUMBER).description("응답 기사 목록 중 마지막 기사의 id"),
-//                                        PayloadDocumentation.fieldWithPath("data.pit").type(JsonFieldType.STRING).description("해당 검색에 해당하는 point in time 값")
-//
-//                                )
-//                        )
-//                );
     }
 }

--- a/LiveFeedService/src/test/java/com/livefeed/livefeedservice/articlelist/service/ArticleListServiceTest.java
+++ b/LiveFeedService/src/test/java/com/livefeed/livefeedservice/articlelist/service/ArticleListServiceTest.java
@@ -24,7 +24,7 @@ class ArticleListServiceTest {
         // given
         SearchQueryParam searchQueryParam = SearchQueryParam.makeParam(List.of("articleTitle", "bodyHtml"), List.of("SSG"), 3, List.of("id-desc"), null, null, false);
         // when
-        ArticleListDto articleList = articleListService.getArticleList(searchQueryParam);
+        ArticleListDto articleList = articleListService.getArticleList(searchQueryParam, "sseKey");
         // then
 
     }

--- a/LiveFeedService/src/test/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepositoryTest.java
+++ b/LiveFeedService/src/test/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.util.List;
 
+@Disabled
 class RedisUserKeywordRepositoryTest {
 
     private static UserKeywordRepository userKeywordRepository;

--- a/LiveFeedService/src/test/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepositoryTest.java
+++ b/LiveFeedService/src/test/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.livefeed.livefeedservice.newarticle.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.List;
+
+class RedisUserKeywordRepositoryTest {
+
+    @Test
+    @DisplayName("키워드를 등록했을때 변화가 없는 경우 0을 반환합니다.")
+    void returnZero() {
+        // given
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration("localhost", 6379);
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+        lettuceConnectionFactory.afterPropertiesSet();
+
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(lettuceConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.afterPropertiesSet();
+
+        UserKeywordRepository userKeywordRepository = new RedisUserKeywordRepository(redisTemplate);
+        // when
+        Long first = userKeywordRepository.setUserKeywords("testKey", List.of("key1", "key2"));
+        Long second = userKeywordRepository.setUserKeywords("testKey", List.of("key1", "key2"));
+        // then
+        Assertions.assertThat(first).isEqualTo(2);
+        Assertions.assertThat(second).isEqualTo(0);
+    }
+}

--- a/LiveFeedService/src/test/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepositoryTest.java
+++ b/LiveFeedService/src/test/java/com/livefeed/livefeedservice/newarticle/repository/RedisUserKeywordRepositoryTest.java
@@ -1,8 +1,7 @@
 package com.livefeed.livefeedservice.newarticle.repository;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -12,10 +11,12 @@ import java.util.List;
 
 class RedisUserKeywordRepositoryTest {
 
-    @Test
-    @DisplayName("키워드를 등록했을때 변화가 없는 경우 0을 반환합니다.")
-    void returnZero() {
-        // given
+    private static UserKeywordRepository userKeywordRepository;
+    private final String sseKey = "sseKey";
+
+    @BeforeAll
+    static void setUp() {
+        System.out.println("test class start");
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration("localhost", 6379);
         LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
         lettuceConnectionFactory.afterPropertiesSet();
@@ -26,12 +27,70 @@ class RedisUserKeywordRepositoryTest {
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         redisTemplate.afterPropertiesSet();
 
-        UserKeywordRepository userKeywordRepository = new RedisUserKeywordRepository(redisTemplate);
+        userKeywordRepository = new RedisUserKeywordRepository(redisTemplate);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        userKeywordRepository.deleteUserKeywords(sseKey);
+    }
+
+    @DisplayName("기존에 등록된 키워드가 없고 새로 등록할 키워드도 없는 경우 0을 반환합니다.")
+    @Test
+    void noKeyWords() {
+        // given
         // when
-        Long first = userKeywordRepository.setUserKeywords("testKey", List.of("key1", "key2"));
-        Long second = userKeywordRepository.setUserKeywords("testKey", List.of("key1", "key2"));
+        int result = userKeywordRepository.updateUserKeywords(sseKey, List.of());
+        // then
+        Assertions.assertThat(result).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("키워드를 등록했을때 변화가 없는 경우 0을 반환합니다.")
+    void returnZero() {
+        // when
+        int first = userKeywordRepository.updateUserKeywords(sseKey, List.of("key1", "key2"));
+        int second = userKeywordRepository.updateUserKeywords(sseKey, List.of("key1", "key2"));
         // then
         Assertions.assertThat(first).isEqualTo(2);
         Assertions.assertThat(second).isEqualTo(0);
+    }
+
+    @DisplayName("기존 키워드에서 한 개의 키워드가 사라진 경우 사라진 개수를 반환합니다.")
+    @Test
+    void setUserKeyword() {
+        // given
+        // when
+        int first = userKeywordRepository.updateUserKeywords(sseKey, List.of("key1", "key2"));
+        int second = userKeywordRepository.updateUserKeywords(sseKey, List.of("key1"));
+        // then
+        Assertions.assertThat(first).isEqualTo(2);
+        Assertions.assertThat(second).isEqualTo(1);
+    }
+
+    @DisplayName("기존 키워드가 존재하며 새로 등록하는 키워드가 없는 경우 사라진 개수를 반환합니다.")
+    @Test
+    void setUserKeywordRemove() {
+        // given
+        // when
+        int first = userKeywordRepository.updateUserKeywords(sseKey, List.of("key1", "key2"));
+        int second = userKeywordRepository.updateUserKeywords(sseKey, List.of());
+
+        // then
+        Assertions.assertThat(first).isEqualTo(2);
+        Assertions.assertThat(second).isEqualTo(2);
+    }
+
+    @DisplayName("기존 키워드와 하나만 동일하고 나머지가 다른 키워드를 등록하는 경우")
+    @Test
+    void setUserKeywordAnother() {
+        // given
+        // when
+        int first = userKeywordRepository.updateUserKeywords(sseKey, List.of("key1", "key2"));
+        int second = userKeywordRepository.updateUserKeywords(sseKey, List.of("key1", "key3", "key4"));
+
+        // then
+        Assertions.assertThat(first).isEqualTo(2);
+        Assertions.assertThat(second).isEqualTo(3);
     }
 }

--- a/LiveFeedService/src/test/resources/application-test.yaml
+++ b/LiveFeedService/src/test/resources/application-test.yaml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: false
+        format_sql: false
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true
+      multiline: true
+      
+logging:
+  level:
+    org.springframework.data.elasticsearch.core: DEBUG
+    org.elasticsearch.client: TRACE
+    org.apache.http: TRACE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,8 @@ services:
     restart: always
 
   oracledb:
-    image: oracle/database:19.3.0-ee
+#    image: oracle/database:19.3.0-ee
+    image: ghcr.io/live-feed/live-feed-oracledb:dev
     container_name: oracledb
     ports:
       - "1521:1521"

--- a/http/LiveFeedService/articledetail/articledetail.http
+++ b/http/LiveFeedService/articledetail/articledetail.http
@@ -2,7 +2,8 @@
 GET http://localhost:8084/api/detail/articles/1
 
 ### 기사 목록을 전달하는 api
-GET http://localhost:8084/api/list/articles?type=articleTitle,bodyHtml&keyword=바르셀로나,김민재&size=10&related=true
+GET http://localhost:8084/api/list/articles?type=articleTitle,bodyHtml&keyword=바르셀로나,김민재,손흥민&size=10&related=true
+Cookie: sseKey=asdfasdf
 #GET http://localhost:8084/api/list/articles?type=articleTitle&keyword=페이커&size=4&sort=id-desc
 
 ### search 쿼리가 아닌 api

--- a/http/LiveFeedService/articledetail/articledetail.http
+++ b/http/LiveFeedService/articledetail/articledetail.http
@@ -2,8 +2,8 @@
 GET http://localhost:8084/api/detail/articles/1
 
 ### 기사 목록을 전달하는 api
-GET http://localhost:8084/api/list/articles?type=headerHtml&keyword=손흥민&size=3&sort=id-desc
+GET http://localhost:8084/api/list/articles?type=articleTitle,bodyHtml&keyword=바르셀로나,김민재&size=10&related=true
 #GET http://localhost:8084/api/list/articles?type=articleTitle&keyword=페이커&size=4&sort=id-desc
 
 ### search 쿼리가 아닌 api
-GET http://localhost:8084/api/list/articles?size=4&sort=id-desc
+GET http://localhost:8084/api/list/articles?size=4&related=true


### PR DESCRIPTION
- 기사 요청을 받을 때 keywords 를 redis에 업데이트 하도록 수정
- 기사 요청을 받을 때 기존과 다른 keyword가 들어온다면 KeywordEvent 발행
- 기사 요청 api 모듈 구조 변경