### PR TITLE
[Lf 73/sse connect] server sent event 관련 내용 수정

### DIFF
--- a/LiveFeedService/build.gradle
+++ b/LiveFeedService/build.gradle
@@ -7,7 +7,7 @@ configurations {
     asciidoctorExt
 }
 
-version = '0.2.8'
+version = '0.2.9'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/common/configuration/WebConfiguration.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/common/configuration/WebConfiguration.java
@@ -22,7 +22,10 @@ public class WebConfiguration {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 String[] urls = origins.toArray(new String[0]);
-                registry.addMapping("/**").allowedOrigins(urls);
+                registry.addMapping("/**")
+                        .allowedOrigins(urls)
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
             }
         };
     }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/controller/SseController.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/controller/SseController.java
@@ -1,5 +1,6 @@
 package com.livefeed.livefeedservice.newarticle.controller;
 
+import com.livefeed.livefeedservice.newarticle.service.CookieService;
 import com.livefeed.livefeedservice.newarticle.service.SseService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,14 +18,15 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class SseController {
 
-    private static final String COOKIE_KEY = "sseKey";
-
     private final SseService sseService;
+    private final CookieService cookieService;
 
     @GetMapping(value = "/register", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter register(HttpServletResponse response) {
         String emitterKey = sseService.generateKey();
-        response.addCookie(new Cookie(COOKIE_KEY, emitterKey));
+        Cookie cookie = cookieService.makeSseKeyCookie(emitterKey);
+        response.addCookie(cookie);
+        log.info("new server sent event connect with sseKey = {}", emitterKey);
         return sseService.register(emitterKey);
     }
 }

--- a/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/service/CookieService.java
+++ b/LiveFeedService/src/main/java/com/livefeed/livefeedservice/newarticle/service/CookieService.java
@@ -1,0 +1,29 @@
+package com.livefeed.livefeedservice.newarticle.service;
+
+import jakarta.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CookieService {
+
+    @Value("${cookie.secure}")
+    private boolean secure;
+
+    @Value("${cookie.domain}")
+    private String domain;
+
+    private static final String COOKIE_KEY = "sseKey";
+    private static final int MAX_AGE = 24 * 60 * 60;
+    private static final String PATH = "/";
+
+    public Cookie makeSseKeyCookie(String emitterKey) {
+        Cookie cookie = new Cookie(COOKIE_KEY, emitterKey);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secure);
+        cookie.setDomain(domain);
+        cookie.setPath(PATH);
+        cookie.setMaxAge(MAX_AGE);
+        return cookie;
+    }
+}

--- a/LiveFeedService/src/main/resources/application-prod.yaml
+++ b/LiveFeedService/src/main/resources/application-prod.yaml
@@ -52,6 +52,10 @@ server:
 application:
   allow-origins: ${ALLOW_ORIGINS}
 
+cookie:
+  secure: true
+  domain: ${COOKIE_DOMAIN}
+
 decorator:
   datasource:
     p6spy:


### PR DESCRIPTION
- redis 유저 키워드 데이터 ttl 1일 적용
- SseEmitter 객체 onCompletion 메서드 실행 시 해당 sseKey 를 갖는 redis 데이터도 삭제하도록 추가
- CookieService 를 통해 SseService 와 역할 분리